### PR TITLE
Implement viewForFooterInSection() in UITableView's delegate

### DIFF
--- a/DropdownMenu/DropdownMenu.swift
+++ b/DropdownMenu/DropdownMenu.swift
@@ -383,4 +383,8 @@ extension DropdownMenu: UITableViewDelegate {
         sectionHeader.titleLabel.text = sections[section].sectionIdentifier
         return sectionHeader
     }
+    
+    public func tableView(_ tableView: UITableView, viewForFooterInSection section: Int) -> UIView? {
+        return nil
+    }
 }


### PR DESCRIPTION
heightForFooterInSection() will not get called without
viewForFooterInSection() implemented, which results in a system default
footer generated for tableview automatically and wrong calculation for tableViewHeight()